### PR TITLE
Add build instructions for TM:PE sync addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# cms-addon-tmpe
+# CSM.TmpeSync Add-on
+
+Dieses Repository enthält ein Add-on für [Cities: Skylines Multiplayer (CSM)](https://github.com/CitiesSkylinesMultiplayer/CSM),
+das die Synchronisation der Geschwindigkeitsbegrenzungen aus [Traffic Manager: President Edition (TM:PE)](https://github.com/CitiesSkylinesMods/TMPE) aktiviert.
+Die folgenden Schritte zeigen dir, wie du das Projekt lokal baust und das resultierende Add-on im Spiel verwendest.
+
+## Voraussetzungen
+
+* .NET SDK 6.0 (oder neuer) – wird für den `dotnet`-Build benötigt.
+* Cities: Skylines ist lokal installiert (Steam oder GOG). Du benötigst die DLLs aus
+  `Cities_Data/Managed`.
+* [CitiesHarmony](https://steamcommunity.com/workshop/filedetails/?id=2040656402) (Workshop 2040656402) ist installiert, damit `CitiesHarmony.Harmony.dll` verfügbar ist.
+* Das CSM-Hauptprojekt muss bereits gebaut sein, damit `CSM.API.dll` vorliegt.
+  * Alternativ kannst du die Datei in einen lokalen `lib/`-Ordner neben dieses Repository kopieren.
+* Optional: TM:PE muss installiert sein, wenn du direkt auf `TrafficManager.dll` verweist.
+
+> 💡 Lege die benötigten DLLs nicht ins Repository, sondern verweise beim Build auf die bereits vorhandenen Installationen.
+
+## Build in Visual Studio Code
+
+1. Öffne den Ordner des Repositories in VS Code.
+2. Installiere die Erweiterung **C# Dev Kit** oder **C#** (für IntelliSense und Build-Aufgaben).
+3. Erstelle eine `Directory.Build.props` (oder setze Umgebungsvariablen), damit die Build-Pfade bekannt sind:
+
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <Project>
+     <PropertyGroup>
+       <!-- Passe die Pfade an deine Installation an -->
+       <CitiesSkylinesDir>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines</CitiesSkylinesDir>
+       <HarmonyDllDir>C:\Program Files (x86)\Steam\steamapps\workshop\content\255710\2040656402</HarmonyDllDir>
+       <CsmApiDllPath>D:\Repos\CSM\API\bin\Release\CSM.API.dll</CsmApiDllPath>
+       <!-- Optional, nur wenn benötigt: -->
+       <TmpeDir>C:\Program Files (x86)\Steam\steamapps\workshop\content\255710\1637663252</TmpeDir>
+     </PropertyGroup>
+   </Project>
+   ```
+
+   Speichere die Datei im Repository-Stamm. Beim Build werden die Pfade automatisch übernommen.
+
+4. Führe den Build aus:
+
+   ```bash
+   dotnet build src/CSM.TmpeSync.csproj -c Release
+   ```
+
+   Der Build schlägt fehl, falls eine der DLLs nicht gefunden wird. In diesem Fall passe die Pfade an.
+
+5. Nach erfolgreichem Build kopiert das `AfterBuild`-Target die erzeugte `CSM.FileSync.dll`
+   automatisch nach `%LOCALAPPDATA%\Colossal Order\Cities_Skylines\Addons\Mods\CSM.TmpeSync`.
+
+## Add-on im Spiel verwenden
+
+1. Starte Cities: Skylines und aktiviere im Content-Manager unter **Mods** sowohl CSM als auch das neue Add-on "CSM.TmpeSync".
+2. Stelle sicher, dass sowohl der CSM-Server als auch alle Clients TM:PE installiert und aktiviert haben.
+3. Sobald die Multiplayer-Sitzung läuft, synchronisiert das Add-on Geschwindigkeitsänderungen aus TM:PE zwischen allen Spielern.
+
+## Fehlerbehebung
+
+* **`ICities.dll nicht gefunden`** – Setze die MSBuild-Eigenschaft `CitiesSkylinesDir` auf den korrekten Installationspfad.
+* **`CitiesHarmony.Harmony.dll nicht gefunden`** – Installiere CitiesHarmony im Steam Workshop oder gib `HarmonyDllDir` explizit an.
+* **`CSM.API.dll nicht gefunden`** – Baue zuerst das CSM-Projekt (`dotnet build` im CSM-Repo) und verweise auf die erzeugte DLL
+  via `CsmApiDllPath` oder lege sie in `lib/CSM.API.dll`.
+* **Die DLL landet nicht im Mods-Ordner** – Prüfe, ob `%LOCALAPPDATA%` korrekt gesetzt ist. Alternativ kannst du die Ausgabe
+  im Projekt-Ordner `src/bin/Release/net35/` manuell in den Mods-Ordner kopieren.
+
+Viel Erfolg beim Ausprobieren!


### PR DESCRIPTION
## Summary
- document prerequisites and path configuration required to build the TM:PE sync addon
- add detailed steps for building via VS Code and deploying the DLL into the Cities: Skylines mods folder
- outline troubleshooting tips for missing dependencies like ICities.dll and CSM.API.dll

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66594e1d48327b03742f41057d520