### PR TITLE
Use protobuf-net version compatible with .NET 3.5

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -85,7 +85,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.2.31" />
+    <PackageReference Include="protobuf-net" Version="2.4.6" />
   </ItemGroup>
 
   <!-- ==== Dateien (da EnableDefaultCompileItems=false) ==== -->


### PR DESCRIPTION
## Summary
- downgrade protobuf-net dependency so it remains compatible with the net35 target

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e66e16ab708327aa134afe54741e3d