### PR TITLE
Fix build errors when compiling outside game

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -105,6 +105,7 @@
 
     <Compile Include="Stubs\CsmApiStubs.cs" />
     <Compile Include="Stubs\ICitiesStubs.cs" />
+    <Compile Include="Stubs\UnityEngineStubs.cs" />
 
     <Compile Include="Net\Contracts\Requests\SetSpeedLimitRequest.cs" />
     <Compile Include="Net\Contracts\Applied\SpeedLimitApplied.cs" />

--- a/src/Snapshot/SpeedLimitSnapshotProvider.cs
+++ b/src/Snapshot/SpeedLimitSnapshotProvider.cs
@@ -1,3 +1,4 @@
+using CSM.API;
 using CSM.API.Commands;
 using CSM.TmpeSync.Net.Contracts.Applied;
 using CSM.TmpeSync.Util;

--- a/src/Stubs/UnityEngineStubs.cs
+++ b/src/Stubs/UnityEngineStubs.cs
@@ -1,0 +1,11 @@
+#if !GAME
+namespace UnityEngine
+{
+    public static class Debug
+    {
+        public static void Log(object message) { }
+        public static void LogWarning(object message) { }
+        public static void LogError(object message) { }
+    }
+}
+#endif

--- a/src/Util/DeferredApply.cs
+++ b/src/Util/DeferredApply.cs
@@ -23,7 +23,8 @@ namespace CSM.TmpeSync.Util
                 if(wait>0){ wait--; yield return 0; continue; }
                 Entry[] work; lock(_queue) work=_queue.ToArray();
                 if(work.Length==0){ _running=false; yield break; }
-                foreach(var e in work){
+                for(int i=0;i<work.Length;i++){
+                    var e=work[i];
                     bool done=false, drop=false;
                     try{
                         if(e.Op.Exists()){
@@ -38,6 +39,11 @@ namespace CSM.TmpeSync.Util
                         lock(_queue){ for(int i=0;i<_queue.Count;i++) if(object.ReferenceEquals(_queue[i].Op,e.Op)){ _queue.RemoveAt(i); break; } }
                         if(done) Log.Info("DeferredApply applied {0} after {1} retries", e.Op.Key, e.Retries);
                         else Log.Warn("DeferredApply dropped {0} after {1} retries", e.Op.Key, e.Retries);
+                    }
+                    else if(!done){
+                        lock(_queue){
+                            for(int j=0;j<_queue.Count;j++) if(object.ReferenceEquals(_queue[j].Op,e.Op)){ var entry=_queue[j]; entry.Retries=e.Retries; _queue[j]=entry; break; }
+                        }
                     }
                 }
                 wait=DELAY_FRAMES; yield return 0;


### PR DESCRIPTION
## Summary
- add UnityEngine debug stub for non-game builds and include it in the project
- ensure snapshot provider can resolve the Command helper when using API stubs
- rework deferred apply retry loop to avoid modifying foreach iteration variables

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e66e906d088327b2f5104e4cf6a77e