### PR TITLE
Enforce dependency gating for TM:PE sync add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Die folgenden Schritte zeigen dir, wie du das Projekt lokal baust und das result
 
 ## Add-on im Spiel verwenden
 
-1. Starte Cities: Skylines und aktiviere im Content-Manager unter **Mods** sowohl CSM als auch das neue Add-on "CSM.TmpeSync".
+1. Starte Cities: Skylines und aktiviere im Content-Manager unter **Mods** sowohl CSM als auch das neue Add-on "CSM.TmpeSync" (das Add-on bleibt nur aktiv, wenn CSM **und** Harmony eingeschaltet sind).
 2. Stelle sicher, dass sowohl der CSM-Server als auch alle Clients TM:PE installiert und aktiviert haben.
-3. Sobald die Multiplayer-Sitzung läuft, synchronisiert das Add-on Geschwindigkeitsänderungen aus TM:PE zwischen allen Spielern.
+3. Sobald die Multiplayer-Sitzung läuft, synchronisiert das Add-on Geschwindigkeitsänderungen aus TM:PE (Speed-Limit aktivieren/deaktivieren) zwischen allen Spielern.
 
 ## Fehlerbehebung
 

--- a/src/Mod/MyUserMod.cs
+++ b/src/Mod/MyUserMod.cs
@@ -7,14 +7,18 @@ namespace CSM.TmpeSync.Mod
     public class MyUserMod : IUserMod
     {
         public string Name => "CSM TM:PE Sync (Host-Authoritative)";
-        public string Description => "Aktiviert nur mit CSM & Harmony. Host setzt via TM:PE; Broadcast an Clients.";
+        public string Description => "Synchronisiert TM:PE-Geschwindigkeitslimits (Ein/Aus) – benötigt CSM & Harmony.";
 
         private static TmpeSyncConnection _conn;
 
         public void OnEnabled(){
             Log.Info("Enable... checking deps");
-            if (!Deps.IsCsmEnabled()){ Log.Error("Missing dependency: CSM not enabled."); return; }
-            if (!Deps.IsHarmonyAvailable()){ Log.Error("Missing dependency: Harmony not available."); return; }
+            var missing = Deps.GetMissingDependencies();
+            if (missing.Length > 0){
+                Log.Error("Missing dependency: {0}. Disabling mod.", string.Join(", ", missing));
+                Deps.DisableSelf(this);
+                return;
+            }
             _conn = new TmpeSyncConnection();
             Helper.RegisterConnection(_conn);
             Log.Info("Deps OK -> active");

--- a/src/Util/Deps.cs
+++ b/src/Util/Deps.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 #if GAME
 using ColossalFramework.Plugins;
@@ -44,10 +45,34 @@ namespace CSM.TmpeSync.Util
             }catch(Exception ex){ Log.Warn("Harmony dep check: {0}", ex); }
             return false;
         }
+        internal static string[] GetMissingDependencies(){
+            var missing = new List<string>();
+            if (!IsCsmEnabled()) missing.Add("CSM");
+            if (!IsHarmonyAvailable()) missing.Add("Harmony");
+            return missing.ToArray();
+        }
+        internal static void DisableSelf(object modInstance){
+            try{
+                foreach (var p in PluginManager.instance.GetPluginsInfo()){
+                    if (p.userModInstance == modInstance){
+                        Log.Warn("Disabling plugin '{0}' due to missing dependencies.", SafeName(p));
+                        var pluginName = p.name;
+                        if (!string.IsNullOrEmpty(pluginName)){
+                            PluginManager.instance.SetPluginEnabled(pluginName, false);
+                        }else{
+                            p.isEnabled = false;
+                        }
+                        break;
+                    }
+                }
+            }catch(Exception ex){ Log.Warn("Failed to disable plugin: {0}", ex); }
+        }
         private static string SafeName(PluginInfo p){ try{ return p.name ?? p.modPath ?? ""; }catch{ return ""; } }
 #else
         internal static bool IsCsmEnabled(){ return false; }
         internal static bool IsHarmonyAvailable(){ return false; }
+        internal static string[] GetMissingDependencies(){ return new[]{"CSM","Harmony"}; }
+        internal static void DisableSelf(object _){ }
         private static string SafeName(object _){ return string.Empty; }
 #endif
     }


### PR DESCRIPTION
## Summary
- disable the TM:PE sync add-on automatically if CSM or Harmony are not enabled
- update the in-game mod description to mention the synced speed limit toggle and dependency requirement
- document the dependency enforcement in the player-facing README instructions

## Testing
- ⚠️ `dotnet build src/CSM.TmpeSync.csproj -c Release` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6714a7e108327bbcc8f750b577f91