### PR TITLE
Add Steam mods copy target

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -40,6 +40,10 @@
     <!-- ===== Mod-Ausgabeordner ===== -->
     <ModsOutDir>$(LOCALAPPDATA)\Colossal Order\Cities_Skylines\Addons\Mods\CSM.TmpeSync</ModsOutDir>
 
+    <!-- ===== Steam-Installation (optional) ===== -->
+    <SteamModsDir Condition="'$(SteamModsDir)'!=''">$(SteamModsDir)</SteamModsDir>
+    <SteamModsDir Condition="'$(SteamModsDir)'=='' and Exists('C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cities_Skylines\\Files\\Mods')">C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cities_Skylines\\Files\\Mods\\CSM.TmpeSync</SteamModsDir>
+  
     <!-- In-Game Compile-Define -->
     <DefineConstants>TRACE;RELEASE</DefineConstants>
   </PropertyGroup>
@@ -130,5 +134,10 @@
   <Target Name="AfterBuild" Condition="'$(GameBuild)'=='true'">
     <MakeDir Directories="$(ModsOutDir)" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModsOutDir)" />
+  </Target>
+
+  <Target Name="CopyToSteamMods" AfterTargets="Build" Condition="'$(SteamModsDir)'!=''">
+    <MakeDir Directories="$(SteamModsDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(SteamModsDir)\$(TargetFileName)" SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- add an optional Steam mods directory property that defaults to the Cities: Skylines Mods folder when available
- copy the built DLL into the Steam Mods folder after every build when the directory is configured

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e672cbedd483279999827ae504f4d2