### PR TITLE
Use stub ICities assembly for non-game builds

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -108,9 +108,8 @@
     <Compile Include="Tmpe\TmpeAdapter.cs" />
 
     <Compile Include="Stubs\CsmApiStubs.cs" />
-    <Compile Include="Stubs\ICitiesStubs.cs" />
     <Compile Include="Stubs\UnityEngineStubs.cs" />
-
+  
     <Compile Include="Net\Contracts\Requests\SetSpeedLimitRequest.cs" />
     <Compile Include="Net\Contracts\Applied\SpeedLimitApplied.cs" />
     <Compile Include="Net\Contracts\System\RequestRejected.cs" />
@@ -128,6 +127,17 @@
     <Compile Include="Snapshot\SpeedLimitSnapshotProvider.cs" />
 
     <Compile Include="Tool\LockOverlay.cs" />
+  </ItemGroup>
+
+  <Target Name="BuildStubReferences" BeforeTargets="ResolveReferences" Condition="'$(GameBuild)'!='true'">
+    <MSBuild Projects="Stubs/ICitiesStub/ICitiesStub.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
+  </Target>
+
+  <ItemGroup Condition="'$(GameBuild)'!='true'">
+    <Reference Include="ICities">
+      <HintPath>$(MSBuildProjectDirectory)\Stubs\ICitiesStub\bin\$(Configuration)\net35\ICities.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <!-- ==== Post-Build: Mod-DLL ins Mods-Verzeichnis ==== -->

--- a/src/Stubs/ICitiesStub/ICitiesStub.csproj
+++ b/src/Stubs/ICitiesStub/ICitiesStub.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net35</TargetFramework>
+    <AssemblyName>ICities</AssemblyName>
+    <RootNamespace>ICities</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/Stubs/ICitiesStub/IUserMod.cs
+++ b/src/Stubs/ICitiesStub/IUserMod.cs
@@ -1,4 +1,3 @@
-#if !GAME
 namespace ICities
 {
     public interface IUserMod
@@ -9,4 +8,3 @@ namespace ICities
         void OnDisabled();
     }
 }
-#endif

--- a/src/Stubs/ICitiesStub/Properties/AssemblyInfo.cs
+++ b/src/Stubs/ICitiesStub/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Reflection;
+
+[assembly: AssemblyTitle("ICities Stub")]
+[assembly: AssemblyDescription("Minimal stub for Cities: Skylines ICities interfaces")]
+[assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
## Summary
- replace the inline ICities `IUserMod` stub with a dedicated stub assembly
- build the stub automatically for non-game builds so the mod references the correct ICities assembly when loaded in-game
- rely on the SDK's implicit compile items in the stub project to avoid duplicate `IUserMod.cs` inclusions during build

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e673d220e0832798207a3c4d89f7b7