### PR TITLE
Add reference assembly packages for net35 compilation

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -90,6 +90,7 @@
 
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="2.4.6" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net35" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- ==== Dateien (da EnableDefaultCompileItems=false) ==== -->

--- a/src/Stubs/ICitiesStub/ICitiesStub.csproj
+++ b/src/Stubs/ICitiesStub/ICitiesStub.csproj
@@ -10,5 +10,6 @@
 
   <ItemGroup>
     <Compile Include="IUserMod.cs" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net35" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add the Microsoft.NETFramework.ReferenceAssemblies.net35 package so the main mod can build without system-wide .NET Framework 3.5
- include the same package in the ICities stub project to provide reference assemblies for its net35 target

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6771d91a88327a4d1c4551f488e24