### PR TITLE
Inline ICities stub for non-game builds

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -130,15 +130,8 @@
     <Compile Include="Tool\LockOverlay.cs" />
   </ItemGroup>
 
-  <Target Name="BuildStubReferences" BeforeTargets="ResolveReferences" Condition="'$(GameBuild)'!='true'">
-    <MSBuild Projects="Stubs/ICitiesStub/ICitiesStub.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
-  </Target>
-
   <ItemGroup Condition="'$(GameBuild)'!='true'">
-    <Reference Include="ICities">
-      <HintPath>$(MSBuildProjectDirectory)\Stubs\ICitiesStub\bin\$(Configuration)\net35\ICities.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
+    <Compile Include="Stubs\ICitiesStub\IUserMod.cs" />
   </ItemGroup>
 
   <!-- ==== Post-Build: Mod-DLL ins Mods-Verzeichnis ==== -->


### PR DESCRIPTION
## Summary
- include the ICities IUserMod stub source directly when building without game assemblies
- remove the custom stub project build step and reference path that required .NET Framework reference assemblies

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e677b5b73c8327b34e4e94c4433e4f