### PR TITLE
Fix PluginInfo alias for release builds

### DIFF
--- a/src/Util/Deps.cs
+++ b/src/Util/Deps.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 #if GAME
 using ColossalFramework.Plugins;
+using PluginInfo = ColossalFramework.Plugins.PluginManager.PluginInfo;
 #endif
 
 namespace CSM.TmpeSync.Util


### PR DESCRIPTION
## Summary
- add an alias for the nested PluginInfo type in Deps.cs so Release builds resolve the Cities: Skylines type correctly

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e67a171ec8832797d86f4cf0f59240