### PR TITLE
Fix missing CsmCompat build inclusion and update plugin reflection

### DIFF
--- a/src/CSM.TmpeSync.csproj
+++ b/src/CSM.TmpeSync.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Util\NetUtil.cs" />
     <Compile Include="Util\EntityLocks.cs" />
     <Compile Include="Util\DeferredApply.cs" />
+    <Compile Include="Util\CsmCompat.cs" />
     <Compile Include="Util\LockRegistry.cs" />
 
     <Compile Include="Tmpe\TmpeAdapter.cs" />

--- a/src/Util/Deps.cs
+++ b/src/Util/Deps.cs
@@ -61,8 +61,9 @@ namespace CSM.TmpeSync.Util
                         var pluginName = p.name;
                         if (!string.IsNullOrEmpty(pluginName)){
                             var manager = PluginManager.instance;
-                            var setMethod = manager.GetType().GetMethod("SetPluginEnabled", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new[]{ typeof(string), typeof(bool) }, null)
-                                            ?? manager.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                            var managerType = manager.GetType();
+                            var setMethod = managerType.GetMethod("SetPluginEnabled", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new[]{ typeof(string), typeof(bool) }, null)
+                                            ?? managerType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                                 .FirstOrDefault(m => m.Name.StartsWith("SetPlugin", StringComparison.OrdinalIgnoreCase)
                                                                  && m.GetParameters().Length == 2
                                                                  && m.GetParameters()[0].ParameterType == typeof(string)


### PR DESCRIPTION
## Summary
- ensure the CsmCompat helper is included in the project build so dependent handlers compile
- update plugin disabling logic to use the PluginManager runtime type when discovering SetPluginEnabled

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e67d11abb48327a796fb909353e30c