### PR TITLE
Fix build errors on older framework targets

### DIFF
--- a/src/Util/CsmCompat.cs
+++ b/src/Util/CsmCompat.cs
@@ -244,7 +244,7 @@ namespace CSM.TmpeSync.Util
 
             var declaring = method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "<unknown type>";
             var parameters = method.GetParameters();
-            var parameterTypes = string.Join(", ", parameters.Select(p => p.ParameterType.Name));
+            var parameterTypes = string.Join(", ", parameters.Select(p => p.ParameterType.Name).ToArray());
             return declaring + "." + method.Name + "(" + parameterTypes + ")";
         }
 

--- a/src/Util/Log.cs
+++ b/src/Util/Log.cs
@@ -213,7 +213,10 @@ namespace CSM.TmpeSync.Util
                 if (string.IsNullOrEmpty(localAppData))
                     return null;
 
-                var directory = Path.Combine(localAppData, "Colossal Order", "Cities_Skylines", "CSM", "Logs");
+                var directory = Path.Combine(localAppData, "Colossal Order");
+                directory = Path.Combine(directory, "Cities_Skylines");
+                directory = Path.Combine(directory, "CSM");
+                directory = Path.Combine(directory, "Logs");
                 Directory.CreateDirectory(directory);
                 return Path.Combine(directory, "CSM.TmpeSync.log");
             }


### PR DESCRIPTION
## Summary
- ensure DescribeMethod formats parameter names via a string array to match available string.Join overloads
- build the log directory path with successive Path.Combine calls that are compatible with older frameworks

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6854f9d6c83279d9cf52b6651fa2f