### PR TITLE
Add verbose logging for CSM API traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,34 @@ Die folgenden Schritte zeigen dir, wie du das Projekt lokal baust und das result
 2. Stelle sicher, dass sowohl der CSM-Server als auch alle Clients TM:PE installiert und aktiviert haben.
 3. Sobald die Multiplayer-Sitzung läuft, synchronisiert das Add-on Geschwindigkeitsänderungen aus TM:PE (Speed-Limit aktivieren/deaktivieren) zwischen allen Spielern.
 
+## Logs einsehen
+
+* Während des Spiels werden alle Meldungen des Add-ons in die Datei `%LOCALAPPDATA%\Colossal Order\Cities_Skylines\CSM.TmpeSync\Logs\CSM.TmpeSync.log` geschrieben.
+* Öffne diesen Pfad im Windows-Explorer, indem du `Win + R` drückst, `%LOCALAPPDATA%\Colossal Order\Cities_Skylines\CSM.TmpeSync\Logs` eingibst und anschließend die Enter-Taste drückst.
+* Die Datei `CSM.TmpeSync.log` kannst du in einem Editor (z. B. Notepad) öffnen, um detaillierte Informationen zum Ablauf und möglichen Fehlern zu sehen.
+* Zusätzlich landen die Meldungen im Ingame-Debug-Panel (`Esc` → Zahnrad → **Debug-Log**) sowie – falls `-logfile` gesetzt ist – in der Unity-Player-Logdatei.
+
+### Unity-Player-Logdatei umleiten (`-logfile`)
+
+* **Steam (empfohlen):**
+  1. Öffne in deiner Steam-Bibliothek die Eigenschaften von Cities: Skylines (`Rechtsklick` → **Eigenschaften**).
+  2. Trage unter **Startoptionen** z. B. folgendes ein:
+
+     ```
+     -logFile "%USERPROFILE%\AppData\LocalLow\Colossal Order\Cities Skylines\Player.log"
+     ```
+
+     Der Ordner wird beim Spielstart automatisch erstellt, falls er noch nicht existiert.
+* **Direktes Starten über eine Verknüpfung oder `Cities.exe`:**
+  * Ergänze das Ziel um `-logFile "C:\Pfad\zu\CitiesPlayer.log"` oder starte das Spiel direkt per Konsole:
+
+    ```powershell
+    "C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities.exe" -logFile "C:\Temp\CitiesPlayer.log"
+    ```
+
+  * Der angegebene Pfad muss beschreibbar sein. Er kann z. B. auf einen gemeinsamen Ordner zeigen, damit mehrere Spieler Logs leichter austauschen können.
+* Entferne die Startoption bzw. das Argument wieder, wenn du die Standardausgabe (`Player.log` im Unity-Standardpfad) verwenden möchtest.
+
 ## Multiplayer-Funktion testen
 
 Um zu prüfen, ob die Synchronisation im Multiplayer wirklich funktioniert, kannst du folgendermaßen vorgehen:
@@ -80,7 +108,7 @@ Um zu prüfen, ob die Synchronisation im Multiplayer wirklich funktioniert, kann
    * Beobachte beim Client, ob die Änderung automatisch erscheint.
    * Wiederhole den Test in die andere Richtung (Client ändert, Server beobachtet), um sicherzugehen, dass die Synchronisation bidirektional funktioniert.
 4. **Log-Dateien prüfen (optional):**
-   * In `%LOCALAPPDATA%\Colossal Order\Cities_Skylines\CSM\Logs` findest du die CSM-Logs. Dort sollte beim Setzen eines Tempolimits eine Meldung mit Bezug auf `SpeedLimitSync` auftauchen.
+  * In `%LOCALAPPDATA%\Colossal Order\Cities_Skylines\CSM.TmpeSync\Logs` findest du die CSM.TmpeSync-Logs. Dort sollte beim Setzen eines Tempolimits eine Meldung mit Bezug auf `SpeedLimitSync` auftauchen.
    * Falls die Änderungen nicht ankommen, vergleiche die Logs von Server und Client – meist sind fehlende oder deaktivierte Mods die Ursache.
 
 Auf diese Weise kannst du zuverlässig nachvollziehen, ob das Add-on die TM:PE-Geschwindigkeitsbegrenzungen für alle verbundenen Spieler synchron hält.

--- a/src/Net/Handlers/Locks/BeginEndHandlers.cs
+++ b/src/Net/Handlers/Locks/BeginEndHandlers.cs
@@ -14,9 +14,20 @@ namespace CSM.TmpeSync.Net.Handlers.Locks
     public class BeginEditRequestHandler : CommandHandler<BeginEditRequest>
     {
         protected override void Handle(BeginEditRequest cmd){
-            if (Command.CurrentRole!=MultiplayerRole.Server) return;
+            var sender=CsmCompat.GetSenderId(cmd);
+            Log.Info("Received BeginEditRequest kind={0} id={1} from client={2}", cmd.TargetKind, cmd.TargetId, sender);
+            if (Command.CurrentRole!=MultiplayerRole.Server){
+                Log.Debug("Ignoring BeginEditRequest on non-server instance.");
+                return;
+            }
             var key=HostLocks.Key(cmd.TargetKind,cmd.TargetId);
-            if (!HostLocks.Owner.ContainsKey(key)) HostLocks.Owner[key]=CsmCompat.GetSenderId(cmd);
+            if (!HostLocks.Owner.ContainsKey(key)){
+                HostLocks.Owner[key]=sender;
+                Log.Debug("Assigned new edit lock owner client={0} for key={1}", sender, key);
+            }
+            else{
+                Log.Debug("Refreshing edit lock for key={0}; owner remains client={1}", key, HostLocks.Owner[key]);
+            }
             CsmCompat.SendToAll(new EditLockApplied{ TargetKind=cmd.TargetKind, TargetId=cmd.TargetId, OwnerClientId=HostLocks.Owner[key], TtlFrames=180 });
         }
     }
@@ -24,8 +35,17 @@ namespace CSM.TmpeSync.Net.Handlers.Locks
     public class EndEditRequestHandler : CommandHandler<EndEditRequest>
     {
         protected override void Handle(EndEditRequest cmd){
-            if (Command.CurrentRole!=MultiplayerRole.Server) return;
-            HostLocks.Owner.Remove(HostLocks.Key(cmd.TargetKind,cmd.TargetId));
+            var sender=CsmCompat.GetSenderId(cmd);
+            Log.Info("Received EndEditRequest kind={0} id={1} from client={2}", cmd.TargetKind, cmd.TargetId, sender);
+            if (Command.CurrentRole!=MultiplayerRole.Server){
+                Log.Debug("Ignoring EndEditRequest on non-server instance.");
+                return;
+            }
+            var key=HostLocks.Key(cmd.TargetKind,cmd.TargetId);
+            if(HostLocks.Owner.Remove(key))
+                Log.Debug("Cleared edit lock key={0} previously owned by client={1}", key, sender);
+            else
+                Log.Warn("EndEditRequest for key={0} had no existing lock", key);
             CsmCompat.SendToAll(new EditLockCleared{ TargetKind=cmd.TargetKind, TargetId=cmd.TargetId });
         }
     }

--- a/src/Net/Handlers/Locks/EditLockAppliedHandler.cs
+++ b/src/Net/Handlers/Locks/EditLockAppliedHandler.cs
@@ -6,6 +6,9 @@ namespace CSM.TmpeSync.Net.Handlers.Locks
 {
     public class EditLockAppliedHandler : CommandHandler<EditLockApplied>
     {
-        protected override void Handle(EditLockApplied cmd){ LockRegistry.Apply(cmd.TargetKind, cmd.TargetId, cmd.OwnerClientId, cmd.TtlFrames); }
+        protected override void Handle(EditLockApplied cmd){
+            Log.Info("Received EditLockApplied kind={0} id={1} owner={2} ttl={3}", cmd.TargetKind, cmd.TargetId, cmd.OwnerClientId, cmd.TtlFrames);
+            LockRegistry.Apply(cmd.TargetKind, cmd.TargetId, cmd.OwnerClientId, cmd.TtlFrames);
+        }
     }
 }

--- a/src/Net/Handlers/Locks/EditLockClearedHandler.cs
+++ b/src/Net/Handlers/Locks/EditLockClearedHandler.cs
@@ -6,6 +6,9 @@ namespace CSM.TmpeSync.Net.Handlers.Locks
 {
     public class EditLockClearedHandler : CommandHandler<EditLockCleared>
     {
-        protected override void Handle(EditLockCleared cmd){ LockRegistry.Clear(cmd.TargetKind, cmd.TargetId); }
+        protected override void Handle(EditLockCleared cmd){
+            Log.Info("Received EditLockCleared kind={0} id={1}", cmd.TargetKind, cmd.TargetId);
+            LockRegistry.Clear(cmd.TargetKind, cmd.TargetId);
+        }
     }
 }

--- a/src/Net/Handlers/SetSpeedLimitRequestHandler.cs
+++ b/src/Net/Handlers/SetSpeedLimitRequestHandler.cs
@@ -12,27 +12,48 @@ namespace CSM.TmpeSync.Net.Handlers
     {
         protected override void Handle(SetSpeedLimitRequest cmd)
         {
-            if (Command.CurrentRole != MultiplayerRole.Server) return;
-
             var senderId=CsmCompat.GetSenderId(cmd);
+            Log.Info("Received SetSpeedLimitRequest lane={0} speed={1}km/h from client={2} role={3}", cmd.LaneId, cmd.SpeedKmh, senderId, Command.CurrentRole);
+
+            if (Command.CurrentRole != MultiplayerRole.Server)
+            {
+                Log.Debug("Ignoring SetSpeedLimitRequest on non-server instance.");
+                return;
+            }
 
             if (!NetUtil.LaneExists(cmd.LaneId)){
+                Log.Warn("Rejecting SetSpeedLimitRequest lane={0} – lane missing on server.", cmd.LaneId);
                 CsmCompat.SendToClient(senderId, new RequestRejected{ Reason="entity_missing", EntityId=cmd.LaneId, EntityType=1 });
                 return;
             }
 
+            Log.Debug("Queueing simulation action to apply speed limit lane={0} -> {1}km/h", cmd.LaneId, cmd.SpeedKmh);
             NetUtil.RunOnSimulation(() =>
             {
-                if (!NetUtil.LaneExists(cmd.LaneId)) return;
+                if (!NetUtil.LaneExists(cmd.LaneId))
+                {
+                    Log.Warn("Simulation step aborted – lane {0} vanished before apply.", cmd.LaneId);
+                    return;
+                }
 
                 using (EntityLocks.AcquireLane(cmd.LaneId))
                 {
-                    if (!NetUtil.LaneExists(cmd.LaneId)) return;
+                    if (!NetUtil.LaneExists(cmd.LaneId))
+                    {
+                        Log.Warn("Skipping apply – lane {0} disappeared while locked.", cmd.LaneId);
+                        return;
+                    }
 
                     if (TmpeAdapter.ApplySpeedLimit(cmd.LaneId, cmd.SpeedKmh))
+                    {
+                        Log.Info("Applied speed limit lane={0} -> {1}km/h; broadcasting update.", cmd.LaneId, cmd.SpeedKmh);
                         CsmCompat.SendToAll(new SpeedLimitApplied { LaneId=cmd.LaneId, SpeedKmh=cmd.SpeedKmh });
+                    }
                     else
+                    {
+                        Log.Error("Failed to apply speed limit lane={0} -> {1}km/h; notifying client {2}.", cmd.LaneId, cmd.SpeedKmh, senderId);
                         CsmCompat.SendToClient(senderId, new RequestRejected{ Reason="tmpe_apply_failed", EntityId=cmd.LaneId, EntityType=1 });
+                    }
                 }
             });
         }

--- a/src/Net/Handlers/SpeedLimitAppliedHandler.cs
+++ b/src/Net/Handlers/SpeedLimitAppliedHandler.cs
@@ -8,12 +8,19 @@ namespace CSM.TmpeSync.Net.Handlers
     {
         protected override void Handle(SpeedLimitApplied cmd)
         {
+            Log.Info("Received SpeedLimitApplied lane={0} -> {1}km/h", cmd.LaneId, cmd.SpeedKmh);
+
             if (NetUtil.LaneExists(cmd.LaneId)){
+                Log.Debug("Lane {0} exists – applying immediately (ignore scope).", cmd.LaneId);
                 using (CsmCompat.StartIgnore())
                 {
-                    Tmpe.TmpeAdapter.ApplySpeedLimit(cmd.LaneId, cmd.SpeedKmh);
+                    if (Tmpe.TmpeAdapter.ApplySpeedLimit(cmd.LaneId, cmd.SpeedKmh))
+                        Log.Info("Applied remote speed limit lane={0} -> {1}km/h", cmd.LaneId, cmd.SpeedKmh);
+                    else
+                        Log.Error("Failed to apply remote speed limit lane={0} -> {1}km/h", cmd.LaneId, cmd.SpeedKmh);
                 }
             } else {
+                Log.Warn("Lane {0} missing – queueing deferred speed limit apply.", cmd.LaneId);
                 DeferredApply.Enqueue(new SpeedLimitDeferredOp(cmd));
             }
         }

--- a/src/Net/Handlers/SpeedLimitDeferredOp.cs
+++ b/src/Net/Handlers/SpeedLimitDeferredOp.cs
@@ -9,6 +9,18 @@ namespace CSM.TmpeSync.Net.Handlers
         public SpeedLimitDeferredOp(SpeedLimitApplied cmd){ _cmd=cmd; }
         public string Key => "Speed@Lane:"+_cmd.LaneId;
         public bool Exists(){ return NetUtil.LaneExists(_cmd.LaneId); }
-        public bool TryApply(){ if(!NetUtil.LaneExists(_cmd.LaneId)) return false; return Tmpe.TmpeAdapter.ApplySpeedLimit(_cmd.LaneId,_cmd.SpeedKmh); }
+        public bool TryApply(){
+            if(!NetUtil.LaneExists(_cmd.LaneId)){
+                Log.Debug("Deferred speed limit lane={0} still missing", _cmd.LaneId);
+                return false;
+            }
+
+            var success=Tmpe.TmpeAdapter.ApplySpeedLimit(_cmd.LaneId,_cmd.SpeedKmh);
+            if(success)
+                Log.Info("Deferred speed limit applied lane={0} -> {1}km/h", _cmd.LaneId, _cmd.SpeedKmh);
+            else
+                Log.Error("Deferred speed limit failed lane={0} -> {1}km/h", _cmd.LaneId, _cmd.SpeedKmh);
+            return success;
+        }
     }
 }

--- a/src/Snapshot/SpeedLimitSnapshotProvider.cs
+++ b/src/Snapshot/SpeedLimitSnapshotProvider.cs
@@ -8,10 +8,13 @@ namespace CSM.TmpeSync.Snapshot
     public class SpeedLimitSnapshotProvider : ISnapshotProvider
     {
         public void Export(){
+            Log.Info("Exporting TM:PE speed limits snapshot");
             NetUtil.ForEachLane(laneId=>{
                 float kmh;
-                if (Tmpe.TmpeAdapter.TryGetSpeedKmh(laneId, out kmh))
+                if (Tmpe.TmpeAdapter.TryGetSpeedKmh(laneId, out kmh)){
+                    Log.Debug("Snapshot lane={0} speed={1}km/h", laneId, kmh);
                     CsmCompat.SendToAll(new SpeedLimitApplied{ LaneId=laneId, SpeedKmh=kmh });
+                }
             });
         }
         public void Import(){ }

--- a/src/Util/CsmCompat.cs
+++ b/src/Util/CsmCompat.cs
@@ -244,7 +244,7 @@ namespace CSM.TmpeSync.Util
 
             var declaring = method.DeclaringType?.FullName ?? method.DeclaringType?.Name ?? "<unknown type>";
             var parameters = method.GetParameters();
-            var parameterTypes = string.Join(", ", parameters.Select(p => p.ParameterType.Name));
+            var parameterTypes = string.Join(", ", parameters.Select(p => p.ParameterType.Name).ToArray());
             return declaring + "." + method.Name + "(" + parameterTypes + ")";
         }
 

--- a/src/Util/LockRegistry.cs
+++ b/src/Util/LockRegistry.cs
@@ -8,8 +8,16 @@ namespace CSM.TmpeSync.Util
         private static readonly Dictionary<string,LockInfo> _locks=new Dictionary<string,LockInfo>();
         internal static string Key(byte k, uint id)=>k+":"+id;
 
-        internal static void Apply(byte k,uint id,int owner,int ttl){ _locks[Key(k,id)]=new LockInfo{Owner=owner,Ttl=ttl}; }
-        internal static void Clear(byte k,uint id){ _locks.Remove(Key(k,id)); }
+        internal static void Apply(byte k,uint id,int owner,int ttl){
+            _locks[Key(k,id)]=new LockInfo{Owner=owner,Ttl=ttl};
+            Log.Debug("Lock applied kind={0} id={1} owner={2} ttl={3}", k, id, owner, ttl);
+        }
+        internal static void Clear(byte k,uint id){
+            if(_locks.Remove(Key(k,id)))
+                Log.Debug("Lock cleared kind={0} id={1}", k, id);
+            else
+                Log.Debug("Lock clear request for missing kind={0} id={1}", k, id);
+        }
         internal static bool IsLocked(byte k,uint id){ LockInfo li; return _locks.TryGetValue(Key(k,id), out li) && li.Ttl>0; }
         internal static void Tick(){
             var rm=new List<string>(_locks.Keys);

--- a/src/Util/Log.cs
+++ b/src/Util/Log.cs
@@ -213,7 +213,10 @@ namespace CSM.TmpeSync.Util
                 if (string.IsNullOrEmpty(localAppData))
                     return null;
 
-                var directory = Path.Combine(localAppData, "Colossal Order", "Cities_Skylines", "CSM", "Logs");
+                var directory = Path.Combine(localAppData, "Colossal Order");
+                directory = Path.Combine(directory, "Cities_Skylines");
+                directory = Path.Combine(directory, "CSM.TmpeSync");
+                directory = Path.Combine(directory, "Logs");
                 Directory.CreateDirectory(directory);
                 return Path.Combine(directory, "CSM.TmpeSync.log");
             }


### PR DESCRIPTION
## Summary
- log each CSM command request and response so that every multiplayer action is written to the mod log
- add detailed success and failure messages for applying speed limits and managing TM:PE edit locks
- include snapshot export tracing and deferred operation status updates in the log file

## Testing
- `dotnet build src/CSM.TmpeSync.csproj -c Release` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6854f9d6c83279d9cf52b6651fa2f