### PR TITLE
1.1.0.0

### DIFF
--- a/src/CSM.TmpeSync.JunctionRestrictions/CSM.TmpeSync.JunctionRestrictions.csproj
+++ b/src/CSM.TmpeSync.JunctionRestrictions/CSM.TmpeSync.JunctionRestrictions.csproj
@@ -277,6 +277,7 @@
     <Compile Include="Handlers\JunctionRestrictionsAppliedCommandHandler.cs" />
     <Compile Include="Handlers\JunctionRestrictionsUpdateRequestHandler.cs" />
     <Compile Include="Services\JunctionRestrictionsSynchronization.cs" />
+    <Compile Include="Services\JunctionRestrictionsStateCache.cs" />
     <Compile Include="Services\JunctionRestrictionsEventListener.cs" />
     <Compile Include="Bridge\**\*.cs" />
   </ItemGroup>

--- a/src/CSM.TmpeSync.JunctionRestrictions/Handlers/JunctionRestrictionsAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.JunctionRestrictions/Handlers/JunctionRestrictionsAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.JunctionRestrictions.Messages;
 using CSM.TmpeSync.JunctionRestrictions.Services;
 using CSM.TmpeSync.Messages.States;
@@ -11,6 +12,11 @@ namespace CSM.TmpeSync.JunctionRestrictions.Handlers
         protected override void Handle(JunctionRestrictionsAppliedCommand command)
         {
             ProcessEntry(command.NodeId, command.SegmentId, command.State ?? new JunctionRestrictionsState(), "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            JunctionRestrictionsSynchronization.HandleClientConnect(player);
         }
 
         internal static void ProcessEntry(ushort nodeId, ushort segmentId, JunctionRestrictionsState state, string origin)

--- a/src/CSM.TmpeSync.JunctionRestrictions/Services/JunctionRestrictionsStateCache.cs
+++ b/src/CSM.TmpeSync.JunctionRestrictions/Services/JunctionRestrictionsStateCache.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.JunctionRestrictions.Messages;
+
+namespace CSM.TmpeSync.JunctionRestrictions.Services
+{
+    /// <summary>
+    /// Caches the last applied junction restriction states so the host can resync them to reconnecting clients.
+    /// </summary>
+    internal static class JunctionRestrictionsStateCache
+    {
+        private struct JunctionKey
+        {
+            internal readonly ushort NodeId;
+            internal readonly ushort SegmentId;
+
+            internal JunctionKey(ushort nodeId, ushort segmentId)
+            {
+                NodeId = nodeId;
+                SegmentId = segmentId;
+            }
+
+            public override int GetHashCode() => (NodeId << 16) ^ SegmentId;
+
+            public override bool Equals(object obj)
+            {
+                return obj is JunctionKey other && other.NodeId == NodeId && other.SegmentId == SegmentId;
+            }
+        }
+
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<JunctionKey, JunctionRestrictionsAppliedCommand> Cache =
+            new Dictionary<JunctionKey, JunctionRestrictionsAppliedCommand>();
+
+        internal static void Store(JunctionRestrictionsAppliedCommand state)
+        {
+            if (state == null || state.NodeId == 0 || state.SegmentId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Cache[new JunctionKey(state.NodeId, state.SegmentId)] =
+                    JunctionRestrictionsSynchronization.CloneApplied(state);
+            }
+        }
+
+        internal static List<JunctionRestrictionsAppliedCommand> GetAll()
+        {
+            lock (Gate)
+            {
+                return Cache
+                    .Values
+                    .Select(JunctionRestrictionsSynchronization.CloneApplied)
+                    .ToList();
+            }
+        }
+    }
+}

--- a/src/CSM.TmpeSync.LaneArrows/Handlers/LaneArrowsAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.LaneArrows/Handlers/LaneArrowsAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.LaneArrows.Messages;
 using CSM.TmpeSync.LaneArrows.Services;
 using CSM.TmpeSync.Services;
@@ -10,6 +11,11 @@ namespace CSM.TmpeSync.LaneArrows.Handlers
         protected override void Handle(LaneArrowsAppliedCommand cmd)
         {
             Process(cmd, "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            LaneArrowSynchronization.HandleClientConnect(player);
         }
 
         internal static void Process(LaneArrowsAppliedCommand cmd, string origin)

--- a/src/CSM.TmpeSync.LaneArrows/Services/LaneArrowStateCache.cs
+++ b/src/CSM.TmpeSync.LaneArrows/Services/LaneArrowStateCache.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.LaneArrows.Messages;
+
+namespace CSM.TmpeSync.LaneArrows.Services
+{
+    /// <summary>
+    /// Caches last applied lane-arrow states so the host can resync them to reconnecting clients.
+    /// Keys include node/segment/startNode to separate both ends.
+    /// </summary>
+    internal static class LaneArrowStateCache
+    {
+        private struct EndKey
+        {
+            internal readonly ushort NodeId;
+            internal readonly ushort SegmentId;
+            internal readonly bool StartNode;
+
+            internal EndKey(ushort nodeId, ushort segmentId, bool startNode)
+            {
+                NodeId = nodeId;
+                SegmentId = segmentId;
+                StartNode = startNode;
+            }
+
+            public override int GetHashCode() => (NodeId << 16) ^ SegmentId ^ (StartNode ? 1 : 0);
+
+            public override bool Equals(object obj)
+            {
+                return obj is EndKey other &&
+                       other.NodeId == NodeId &&
+                       other.SegmentId == SegmentId &&
+                       other.StartNode == StartNode;
+            }
+        }
+
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<EndKey, LaneArrowsAppliedCommand> Cache =
+            new Dictionary<EndKey, LaneArrowsAppliedCommand>();
+
+        internal static void Store(LaneArrowsAppliedCommand state)
+        {
+            if (state == null || state.NodeId == 0 || state.SegmentId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Cache[new EndKey(state.NodeId, state.SegmentId, state.StartNode)] =
+                    LaneArrowSynchronization.CloneApplied(state);
+            }
+        }
+
+        internal static List<LaneArrowsAppliedCommand> GetAll()
+        {
+            lock (Gate)
+            {
+                return Cache
+                    .Values
+                    .Select(LaneArrowSynchronization.CloneApplied)
+                    .ToList();
+            }
+        }
+    }
+}

--- a/src/CSM.TmpeSync.LaneConnector/Handlers/LaneConnectorAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.LaneConnector/Handlers/LaneConnectorAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.LaneConnector.Messages;
 using CSM.TmpeSync.LaneConnector.Services;
 
@@ -9,6 +10,11 @@ namespace CSM.TmpeSync.LaneConnector.Handlers
         protected override void Handle(LaneConnectorAppliedCommand cmd)
         {
             LaneConnectorSynchronization.HandleAppliedCommand(cmd);
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            LaneConnectorSynchronization.HandleClientConnect(player);
         }
     }
 }

--- a/src/CSM.TmpeSync.LaneConnector/Services/LaneConnectorStateCache.cs
+++ b/src/CSM.TmpeSync.LaneConnector/Services/LaneConnectorStateCache.cs
@@ -60,6 +60,17 @@ namespace CSM.TmpeSync.LaneConnector.Services
             }
         }
 
+        internal static List<LaneConnectorAppliedCommand> GetAll()
+        {
+            lock (SyncRoot)
+            {
+                return Cache
+                    .Values
+                    .Select(LaneConnectorSynchronization.CloneApplied)
+                    .ToList();
+            }
+        }
+
         internal static List<LaneConnectorAppliedCommand> GetByNode(ushort nodeId)
         {
             lock (SyncRoot)

--- a/src/CSM.TmpeSync.LaneConnector/Services/LaneConnectorSynchronization.cs
+++ b/src/CSM.TmpeSync.LaneConnector/Services/LaneConnectorSynchronization.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.LaneConnector.Messages;
 using CSM.TmpeSync.Messages.System;
 using CSM.TmpeSync.Services;
@@ -9,6 +10,30 @@ namespace CSM.TmpeSync.LaneConnector.Services
 {
     internal static class LaneConnectorSynchronization
     {
+        internal static void HandleClientConnect(Player player)
+        {
+            if (!CsmBridge.IsServerInstance())
+                return;
+
+            int clientId = CsmBridge.TryGetClientId(player);
+            if (clientId < 0)
+                return;
+
+            var cachedStates = LaneConnectorStateCache.GetAll();
+            if (cachedStates == null || cachedStates.Count == 0)
+                return;
+
+            Log.Info(
+                LogCategory.Synchronization,
+                LogRole.Host,
+                "[LaneConnector] Resync for reconnecting client | target={0} items={1}",
+                clientId,
+                cachedStates.Count);
+
+            foreach (var state in cachedStates)
+                CsmBridge.SendToClient(clientId, state);
+        }
+
         internal static void HandleAppliedCommand(LaneConnectorAppliedCommand command)
         {
             if (command == null)

--- a/src/CSM.TmpeSync.ParkingRestrictions/CSM.TmpeSync.ParkingRestrictions.csproj
+++ b/src/CSM.TmpeSync.ParkingRestrictions/CSM.TmpeSync.ParkingRestrictions.csproj
@@ -302,6 +302,7 @@
     <Compile Include="Handlers\ParkingRestrictionAppliedCommandHandler.cs" />
     <Compile Include="Handlers\ParkingRestrictionUpdateRequestHandler.cs" />
     <Compile Include="Services\ParkingRestrictionSynchronization.cs" />
+    <Compile Include="Services\ParkingRestrictionStateCache.cs" />
     <Compile Include="Services\ParkingRestrictionTmpeAdapter.cs" />
     <Compile Include="Services\ParkingRestrictionEventListener.cs" />
   </ItemGroup>

--- a/src/CSM.TmpeSync.ParkingRestrictions/Handlers/ParkingRestrictionAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.ParkingRestrictions/Handlers/ParkingRestrictionAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.ParkingRestrictions.Messages;
 using CSM.TmpeSync.ParkingRestrictions.Services;
 using CSM.TmpeSync.Messages.States;
@@ -10,6 +11,11 @@ namespace CSM.TmpeSync.ParkingRestrictions.Handlers
         protected override void Handle(ParkingRestrictionAppliedCommand command)
         {
             Process(command.SegmentId, command.State, "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            ParkingRestrictionSynchronization.HandleClientConnect(player);
         }
 
         internal static void Process(ushort segmentId, ParkingRestrictionState state, string origin)

--- a/src/CSM.TmpeSync.ParkingRestrictions/Services/ParkingRestrictionStateCache.cs
+++ b/src/CSM.TmpeSync.ParkingRestrictions/Services/ParkingRestrictionStateCache.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.ParkingRestrictions.Messages;
+
+namespace CSM.TmpeSync.ParkingRestrictions.Services
+{
+    /// <summary>
+    /// Caches last applied parking restriction states per segment so the host can resync them to reconnecting clients.
+    /// </summary>
+    internal static class ParkingRestrictionStateCache
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<ushort, ParkingRestrictionAppliedCommand> Cache =
+            new Dictionary<ushort, ParkingRestrictionAppliedCommand>();
+
+        internal static void Store(ParkingRestrictionAppliedCommand state)
+        {
+            if (state == null || state.SegmentId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Cache[state.SegmentId] = Clone(state);
+            }
+        }
+
+        internal static List<ParkingRestrictionAppliedCommand> GetAll()
+        {
+            lock (Gate)
+            {
+                return Cache
+                    .Values
+                    .Select(Clone)
+                    .ToList();
+            }
+        }
+
+        private static ParkingRestrictionAppliedCommand Clone(ParkingRestrictionAppliedCommand source)
+        {
+            if (source == null)
+                return null;
+
+            return new ParkingRestrictionAppliedCommand
+            {
+                SegmentId = source.SegmentId,
+                State = source.State?.Clone()
+            };
+        }
+    }
+}

--- a/src/CSM.TmpeSync.PrioritySigns/CSM.TmpeSync.PrioritySigns.csproj
+++ b/src/CSM.TmpeSync.PrioritySigns/CSM.TmpeSync.PrioritySigns.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Handlers\PrioritySignAppliedCommandHandler.cs" />
     <Compile Include="Handlers\PrioritySignUpdateRequestHandler.cs" />
     <Compile Include="Services\PrioritySignSynchronization.cs" />
+    <Compile Include="Services\PrioritySignStateCache.cs" />
     <Compile Include="Services\PrioritySignTmpeAdapter.cs" />
     <Compile Include="Services\PrioritySignEventListener.cs" />
   </ItemGroup>

--- a/src/CSM.TmpeSync.PrioritySigns/Handlers/PrioritySignAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.PrioritySigns/Handlers/PrioritySignAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.Messages.States;
 using CSM.TmpeSync.PrioritySigns.Messages;
 using CSM.TmpeSync.PrioritySigns.Services;
@@ -11,6 +12,11 @@ namespace CSM.TmpeSync.PrioritySigns.Handlers
         protected override void Handle(PrioritySignAppliedCommand command)
         {
             ProcessEntry(command.NodeId, command.SegmentId, command.SignType, "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            PrioritySignSynchronization.HandleClientConnect(player);
         }
 
         internal static void ProcessEntry(ushort nodeId, ushort segmentId, PrioritySignType signType, string origin)

--- a/src/CSM.TmpeSync.PrioritySigns/Handlers/PrioritySignUpdateRequestHandler.cs
+++ b/src/CSM.TmpeSync.PrioritySigns/Handlers/PrioritySignUpdateRequestHandler.cs
@@ -118,19 +118,22 @@ namespace CSM.TmpeSync.PrioritySigns.Handlers
                         }
 
                         Log.Info(
-                            LogCategory.Synchronization,
-                            LogRole.Host,
-                            "Priority sign applied | nodeId={0} segmentId={1} sign={2} action=broadcast_node",
-                            command.NodeId,
-                            segId,
-                            signAtEnd);
+                        LogCategory.Synchronization,
+                        LogRole.Host,
+                        "Priority sign applied | nodeId={0} segmentId={1} sign={2} action=broadcast_node",
+                        command.NodeId,
+                        segId,
+                        signAtEnd);
 
-                        PrioritySignSynchronization.Dispatch(new PrioritySignAppliedCommand
+                        var applied = new PrioritySignAppliedCommand
                         {
                             NodeId = command.NodeId,
                             SegmentId = segId,
                             SignType = signAtEnd
-                        });
+                        };
+
+                        PrioritySignStateCache.Store(applied);
+                        PrioritySignSynchronization.Dispatch(PrioritySignSynchronization.CloneApplied(applied));
                     }
                 }
             });

--- a/src/CSM.TmpeSync.PrioritySigns/Services/PrioritySignEventListener.cs
+++ b/src/CSM.TmpeSync.PrioritySigns/Services/PrioritySignEventListener.cs
@@ -266,12 +266,15 @@ namespace CSM.TmpeSync.PrioritySigns.Services
                     signType,
                     context);
 
-                PrioritySignSynchronization.Dispatch(new PrioritySignAppliedCommand
+                var applied = new PrioritySignAppliedCommand
                 {
                     NodeId = nodeId,
                     SegmentId = segmentId,
                     SignType = signType
-                });
+                };
+
+                PrioritySignStateCache.Store(applied);
+                PrioritySignSynchronization.Dispatch(PrioritySignSynchronization.CloneApplied(applied));
                 return;
             }
 

--- a/src/CSM.TmpeSync.PrioritySigns/Services/PrioritySignStateCache.cs
+++ b/src/CSM.TmpeSync.PrioritySigns/Services/PrioritySignStateCache.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.PrioritySigns.Messages;
+
+namespace CSM.TmpeSync.PrioritySigns.Services
+{
+    /// <summary>
+    /// Caches last applied priority sign states so hosts can resync them to reconnecting clients.
+    /// </summary>
+    internal static class PrioritySignStateCache
+    {
+        private struct SignKey
+        {
+            internal readonly ushort NodeId;
+            internal readonly ushort SegmentId;
+
+            internal SignKey(ushort nodeId, ushort segmentId)
+            {
+                NodeId = nodeId;
+                SegmentId = segmentId;
+            }
+
+            public override int GetHashCode() => (NodeId << 16) ^ SegmentId;
+
+            public override bool Equals(object obj)
+            {
+                return obj is SignKey other && other.NodeId == NodeId && other.SegmentId == SegmentId;
+            }
+        }
+
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<SignKey, PrioritySignAppliedCommand> Cache =
+            new Dictionary<SignKey, PrioritySignAppliedCommand>();
+
+        internal static void Store(PrioritySignAppliedCommand state)
+        {
+            if (state == null || state.NodeId == 0 || state.SegmentId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Cache[new SignKey(state.NodeId, state.SegmentId)] = Clone(state);
+            }
+        }
+
+        internal static List<PrioritySignAppliedCommand> GetAll()
+        {
+            lock (Gate)
+            {
+                return Cache.Values.Select(Clone).ToList();
+            }
+        }
+
+        private static PrioritySignAppliedCommand Clone(PrioritySignAppliedCommand source)
+        {
+            if (source == null)
+                return null;
+
+            return new PrioritySignAppliedCommand
+            {
+                NodeId = source.NodeId,
+                SegmentId = source.SegmentId,
+                SignType = source.SignType
+            };
+        }
+    }
+}

--- a/src/CSM.TmpeSync.PrioritySigns/Services/PrioritySignSynchronization.cs
+++ b/src/CSM.TmpeSync.PrioritySigns/Services/PrioritySignSynchronization.cs
@@ -7,6 +7,30 @@ namespace CSM.TmpeSync.PrioritySigns.Services
 {
     internal static class PrioritySignSynchronization
     {
+        internal static void HandleClientConnect(CSM.API.Networking.Player player)
+        {
+            if (!CsmBridge.IsServerInstance())
+                return;
+
+            int clientId = CsmBridge.TryGetClientId(player);
+            if (clientId < 0)
+                return;
+
+            var cached = PrioritySignStateCache.GetAll();
+            if (cached == null || cached.Count == 0)
+                return;
+
+            Log.Info(
+                LogCategory.Synchronization,
+                LogRole.Host,
+                "[PrioritySigns] Resync for reconnecting client | target={0} items={1}",
+                clientId,
+                cached.Count);
+
+            foreach (var state in cached)
+                CsmBridge.SendToClient(clientId, state);
+        }
+
         internal static bool TryRead(ushort nodeId, ushort segmentId, out byte signType)
         {
             return PrioritySignTmpeAdapter.TryGetPrioritySign(nodeId, segmentId, out signType);
@@ -15,6 +39,19 @@ namespace CSM.TmpeSync.PrioritySigns.Services
         internal static bool Apply(ushort nodeId, ushort segmentId, byte signType)
         {
             return PrioritySignTmpeAdapter.ApplyPrioritySign(nodeId, segmentId, signType);
+        }
+
+        internal static PrioritySignAppliedCommand CloneApplied(PrioritySignAppliedCommand source)
+        {
+            if (source == null)
+                return null;
+
+            return new PrioritySignAppliedCommand
+            {
+                NodeId = source.NodeId,
+                SegmentId = source.SegmentId,
+                SignType = source.SignType
+            };
         }
 
         internal static void Dispatch(CommandBase command)

--- a/src/CSM.TmpeSync.SpeedLimits/CSM.TmpeSync.SpeedLimits.csproj
+++ b/src/CSM.TmpeSync.SpeedLimits/CSM.TmpeSync.SpeedLimits.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Handlers\SpeedLimitsAppliedCommandHandler.cs" />
     <Compile Include="Handlers\SpeedLimitsUpdateRequestHandler.cs" />
     <Compile Include="Services\SpeedLimitSynchronization.cs" />
+    <Compile Include="Services\SpeedLimitStateCache.cs" />
     <Compile Include="Services\SpeedLimitTmpeAdapter.cs" />
     <Compile Include="Services\SpeedLimitEventListener.cs" />
     <Compile Include="Services\SpeedLimitAdapter.cs" />

--- a/src/CSM.TmpeSync.SpeedLimits/Handlers/SpeedLimitsAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.SpeedLimits/Handlers/SpeedLimitsAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.SpeedLimits.Messages;
 using CSM.TmpeSync.SpeedLimits.Services;
 using CSM.TmpeSync.Services;
@@ -9,6 +10,43 @@ namespace CSM.TmpeSync.SpeedLimits.Handlers
         protected override void Handle(SpeedLimitsAppliedCommand command)
         {
             Process(command, "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            if (!CsmBridge.IsServerInstance())
+                return;
+
+            int clientId = CsmBridge.TryGetClientId(player);
+            if (clientId < 0)
+                return;
+
+            var defaultStates = SpeedLimitStateCache.GetAllDefaults();
+            var segmentStates = SpeedLimitStateCache.GetAllSegments();
+
+            if ((defaultStates == null || defaultStates.Count == 0) &&
+                (segmentStates == null || segmentStates.Count == 0))
+                return;
+
+            Log.Info(
+                LogCategory.Synchronization,
+                LogRole.Host,
+                "[SpeedLimits] Resync for reconnecting client | target={0} defaults={1} segments={2}",
+                clientId,
+                defaultStates?.Count ?? 0,
+                segmentStates?.Count ?? 0);
+
+            if (defaultStates != null)
+            {
+                foreach (var state in defaultStates)
+                    CsmBridge.SendToClient(clientId, state);
+            }
+
+            if (segmentStates != null)
+            {
+                foreach (var state in segmentStates)
+                    CsmBridge.SendToClient(clientId, state);
+            }
         }
 
         internal static void Process(SpeedLimitsAppliedCommand command, string origin)

--- a/src/CSM.TmpeSync.SpeedLimits/Services/SpeedLimitStateCache.cs
+++ b/src/CSM.TmpeSync.SpeedLimits/Services/SpeedLimitStateCache.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.SpeedLimits.Messages;
+
+namespace CSM.TmpeSync.SpeedLimits.Services
+{
+    /// <summary>
+    /// Tracks last known speed limit states so a host can resync them to newly joining clients.
+    /// Uses lane ordinals/signatures only, avoiding lane-id mismatches on remote clients.
+    /// </summary>
+    internal static class SpeedLimitStateCache
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<ushort, SpeedLimitsAppliedCommand> Segments =
+            new Dictionary<ushort, SpeedLimitsAppliedCommand>();
+
+        private static readonly Dictionary<string, DefaultSpeedLimitAppliedCommand> Defaults =
+            new Dictionary<string, DefaultSpeedLimitAppliedCommand>();
+
+        internal static void StoreSegment(SpeedLimitsAppliedCommand state)
+        {
+            if (state == null || state.SegmentId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Segments[state.SegmentId] = SpeedLimitSynchronization.CloneApplied(state);
+            }
+        }
+
+        internal static void StoreDefault(DefaultSpeedLimitAppliedCommand state)
+        {
+            if (state == null || string.IsNullOrEmpty(state.NetInfoName))
+                return;
+
+            lock (Gate)
+            {
+                Defaults[state.NetInfoName] = SpeedLimitSynchronization.CloneDefault(state);
+            }
+        }
+
+        internal static List<SpeedLimitsAppliedCommand> GetAllSegments()
+        {
+            lock (Gate)
+            {
+                return Segments.Values
+                    .Select(SpeedLimitSynchronization.CloneApplied)
+                    .ToList();
+            }
+        }
+
+        internal static List<DefaultSpeedLimitAppliedCommand> GetAllDefaults()
+        {
+            lock (Gate)
+            {
+                return Defaults.Values
+                    .Select(SpeedLimitSynchronization.CloneDefault)
+                    .ToList();
+            }
+        }
+    }
+}

--- a/src/CSM.TmpeSync.SpeedLimits/Services/SpeedLimitSynchronization.cs
+++ b/src/CSM.TmpeSync.SpeedLimits/Services/SpeedLimitSynchronization.cs
@@ -585,7 +585,7 @@ namespace CSM.TmpeSync.SpeedLimits.Services
             };
         }
 
-        private static DefaultSpeedLimitAppliedCommand CloneDefault(DefaultSpeedLimitAppliedCommand source)
+        internal static DefaultSpeedLimitAppliedCommand CloneDefault(DefaultSpeedLimitAppliedCommand source)
         {
             if (source == null)
                 return null;
@@ -629,6 +629,7 @@ namespace CSM.TmpeSync.SpeedLimits.Services
                     payload.CustomGameSpeed,
                     context ?? "unknown");
 
+                SpeedLimitStateCache.StoreDefault(payload);
                 Dispatch(payload);
             }
             else
@@ -667,6 +668,7 @@ namespace CSM.TmpeSync.SpeedLimits.Services
                     payload.Items?.Count ?? 0,
                     context ?? "unknown");
 
+                SpeedLimitStateCache.StoreSegment(payload);
                 Dispatch(payload);
             }
             else
@@ -695,7 +697,7 @@ namespace CSM.TmpeSync.SpeedLimits.Services
             }
         }
 
-        private static SpeedLimitsAppliedCommand CloneApplied(SpeedLimitsAppliedCommand source)
+        internal static SpeedLimitsAppliedCommand CloneApplied(SpeedLimitsAppliedCommand source)
         {
             if (source == null)
                 return null;

--- a/src/CSM.TmpeSync.ToggleTrafficLights/CSM.TmpeSync.ToggleTrafficLights.csproj
+++ b/src/CSM.TmpeSync.ToggleTrafficLights/CSM.TmpeSync.ToggleTrafficLights.csproj
@@ -182,6 +182,7 @@
     <Compile Include="ToggleTrafficLightsSyncFeature.cs" />
     <Compile Include="Services\ToggleTrafficLightsEventListener.cs" />
     <Compile Include="Services\ToggleTrafficLightsSynchronization.cs" />
+    <Compile Include="Services\ToggleTrafficLightsStateCache.cs" />
     <Compile Include="Services\ToggleTrafficLightsTmpeAdapter.cs" />
     <Compile Include="Messages\ToggleTrafficLightsUpdateRequest.cs" />
     <Compile Include="Messages\ToggleTrafficLightsAppliedCommand.cs" />

--- a/src/CSM.TmpeSync.ToggleTrafficLights/Handlers/ToggleTrafficLightsAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.ToggleTrafficLights/Handlers/ToggleTrafficLightsAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.ToggleTrafficLights.Messages;
 using CSM.TmpeSync.ToggleTrafficLights.Services;
 using CSM.TmpeSync.Services;
@@ -10,6 +11,11 @@ namespace CSM.TmpeSync.ToggleTrafficLights.Handlers
         protected override void Handle(ToggleTrafficLightsAppliedCommand command)
         {
             ProcessEntry(command.NodeId, command.Enabled, "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            ToggleTrafficLightsSynchronization.HandleClientConnect(player);
         }
 
         internal static void ProcessEntry(ushort nodeId, bool enabled, string origin)

--- a/src/CSM.TmpeSync.ToggleTrafficLights/Handlers/ToggleTrafficLightsUpdateRequestHandler.cs
+++ b/src/CSM.TmpeSync.ToggleTrafficLights/Handlers/ToggleTrafficLightsUpdateRequestHandler.cs
@@ -107,11 +107,14 @@ namespace CSM.TmpeSync.ToggleTrafficLights.Handlers
                         command.NodeId,
                         resultingEnabled);
 
-                    ToggleTrafficLightsSynchronization.Dispatch(new ToggleTrafficLightsAppliedCommand
+                    var applied = new ToggleTrafficLightsAppliedCommand
                     {
                         NodeId = command.NodeId,
                         Enabled = resultingEnabled
-                    });
+                    };
+
+                    ToggleTrafficLightsStateCache.Store(applied);
+                    ToggleTrafficLightsSynchronization.Dispatch(ToggleTrafficLightsSynchronization.CloneApplied(applied));
                 }
             });
         }

--- a/src/CSM.TmpeSync.ToggleTrafficLights/Services/ToggleTrafficLightsStateCache.cs
+++ b/src/CSM.TmpeSync.ToggleTrafficLights/Services/ToggleTrafficLightsStateCache.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.ToggleTrafficLights.Messages;
+
+namespace CSM.TmpeSync.ToggleTrafficLights.Services
+{
+    /// <summary>
+    /// Caches last applied traffic-light states so hosts can resync them to reconnecting clients.
+    /// </summary>
+    internal static class ToggleTrafficLightsStateCache
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<ushort, ToggleTrafficLightsAppliedCommand> Cache =
+            new Dictionary<ushort, ToggleTrafficLightsAppliedCommand>();
+
+        internal static void Store(ToggleTrafficLightsAppliedCommand state)
+        {
+            if (state == null || state.NodeId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Cache[state.NodeId] = Clone(state);
+            }
+        }
+
+        internal static List<ToggleTrafficLightsAppliedCommand> GetAll()
+        {
+            lock (Gate)
+            {
+                return Cache
+                    .Values
+                    .Select(Clone)
+                    .ToList();
+            }
+        }
+
+        private static ToggleTrafficLightsAppliedCommand Clone(ToggleTrafficLightsAppliedCommand source)
+        {
+            if (source == null)
+                return null;
+
+            return new ToggleTrafficLightsAppliedCommand
+            {
+                NodeId = source.NodeId,
+                Enabled = source.Enabled
+            };
+        }
+    }
+}

--- a/src/CSM.TmpeSync.ToggleTrafficLights/Services/ToggleTrafficLightsSynchronization.cs
+++ b/src/CSM.TmpeSync.ToggleTrafficLights/Services/ToggleTrafficLightsSynchronization.cs
@@ -6,6 +6,30 @@ namespace CSM.TmpeSync.ToggleTrafficLights.Services
 {
     internal static class ToggleTrafficLightsSynchronization
     {
+        internal static void HandleClientConnect(CSM.API.Networking.Player player)
+        {
+            if (!CsmBridge.IsServerInstance())
+                return;
+
+            int clientId = CsmBridge.TryGetClientId(player);
+            if (clientId < 0)
+                return;
+
+            var cached = ToggleTrafficLightsStateCache.GetAll();
+            if (cached == null || cached.Count == 0)
+                return;
+
+            Log.Info(
+                LogCategory.Synchronization,
+                LogRole.Host,
+                "[TrafficLights] Resync for reconnecting client | target={0} items={1}",
+                clientId,
+                cached.Count);
+
+            foreach (var state in cached)
+                CsmBridge.SendToClient(clientId, state);
+        }
+
         internal static bool TryRead(ushort nodeId, out bool enabled)
         {
             return ToggleTrafficLightsTmpeAdapter.TryGetTrafficLight(nodeId, out enabled);
@@ -14,6 +38,18 @@ namespace CSM.TmpeSync.ToggleTrafficLights.Services
         internal static bool Apply(ushort nodeId, bool enabled)
         {
             return ToggleTrafficLightsTmpeAdapter.ApplyTrafficLight(nodeId, enabled);
+        }
+
+        internal static ToggleTrafficLightsAppliedCommand CloneApplied(ToggleTrafficLightsAppliedCommand source)
+        {
+            if (source == null)
+                return null;
+
+            return new ToggleTrafficLightsAppliedCommand
+            {
+                NodeId = source.NodeId,
+                Enabled = source.Enabled
+            };
         }
 
         internal static void Dispatch(CommandBase command)

--- a/src/CSM.TmpeSync.VehicleRestrictions/CSM.TmpeSync.VehicleRestrictions.csproj
+++ b/src/CSM.TmpeSync.VehicleRestrictions/CSM.TmpeSync.VehicleRestrictions.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Handlers\VehicleRestrictionsAppliedCommandHandler.cs" />
     <Compile Include="Handlers\VehicleRestrictionsUpdateRequestHandler.cs" />
     <Compile Include="Services\VehicleRestrictionSynchronization.cs" />
+    <Compile Include="Services\VehicleRestrictionStateCache.cs" />
     <Compile Include="Services\VehicleRestrictionTmpeAdapter.cs" />
     <Compile Include="Services\VehicleRestrictionEventListener.cs" />
   </ItemGroup>

--- a/src/CSM.TmpeSync.VehicleRestrictions/Handlers/VehicleRestrictionsAppliedCommandHandler.cs
+++ b/src/CSM.TmpeSync.VehicleRestrictions/Handlers/VehicleRestrictionsAppliedCommandHandler.cs
@@ -1,4 +1,5 @@
 using CSM.API.Commands;
+using CSM.API.Networking;
 using CSM.TmpeSync.VehicleRestrictions.Messages;
 using CSM.TmpeSync.VehicleRestrictions.Services;
 using CSM.TmpeSync.Services;
@@ -9,6 +10,11 @@ namespace CSM.TmpeSync.VehicleRestrictions.Handlers
         protected override void Handle(VehicleRestrictionsAppliedCommand command)
         {
             Process(command, "single_command");
+        }
+
+        public override void OnClientConnect(Player player)
+        {
+            VehicleRestrictionSynchronization.HandleClientConnect(player);
         }
 
         internal static void Process(VehicleRestrictionsAppliedCommand command, string origin)

--- a/src/CSM.TmpeSync.VehicleRestrictions/Handlers/VehicleRestrictionsUpdateRequestHandler.cs
+++ b/src/CSM.TmpeSync.VehicleRestrictions/Handlers/VehicleRestrictionsUpdateRequestHandler.cs
@@ -72,7 +72,8 @@ namespace CSM.TmpeSync.VehicleRestrictions.Handlers
                             command.SegmentId,
                             (appliedState?.Items?.Count) ?? 0);
 
-                        CsmBridge.SendToAll(appliedState);
+                        VehicleRestrictionStateCache.Store(appliedState);
+                        CsmBridge.SendToAll(VehicleRestrictionStateCache.Clone(appliedState));
                     }
                     else
                     {

--- a/src/CSM.TmpeSync.VehicleRestrictions/Services/VehicleRestrictionStateCache.cs
+++ b/src/CSM.TmpeSync.VehicleRestrictions/Services/VehicleRestrictionStateCache.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSM.TmpeSync.VehicleRestrictions.Messages;
+
+namespace CSM.TmpeSync.VehicleRestrictions.Services
+{
+    /// <summary>
+    /// Caches last applied vehicle restriction states per segment for host-side resync to reconnecting clients.
+    /// Uses lane ordinals/signatures (not lane ids) so remote clients can resolve locally.
+    /// </summary>
+    internal static class VehicleRestrictionStateCache
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<ushort, VehicleRestrictionsAppliedCommand> Cache =
+            new Dictionary<ushort, VehicleRestrictionsAppliedCommand>();
+
+        internal static void Store(VehicleRestrictionsAppliedCommand state)
+        {
+            if (state == null || state.SegmentId == 0)
+                return;
+
+            lock (Gate)
+            {
+                Cache[state.SegmentId] = Clone(state);
+            }
+        }
+
+        internal static List<VehicleRestrictionsAppliedCommand> GetAll()
+        {
+            lock (Gate)
+            {
+                return Cache
+                    .Values
+                    .Select(Clone)
+                    .ToList();
+            }
+        }
+
+        internal static VehicleRestrictionsAppliedCommand Clone(VehicleRestrictionsAppliedCommand source)
+        {
+            if (source == null)
+                return null;
+
+            var clone = new VehicleRestrictionsAppliedCommand
+            {
+                SegmentId = source.SegmentId
+            };
+
+            if (source.Items != null)
+            {
+                foreach (var entry in source.Items)
+                {
+                    if (entry == null)
+                        continue;
+
+                    clone.Items.Add(new VehicleRestrictionsAppliedCommand.Entry
+                    {
+                        LaneOrdinal = entry.LaneOrdinal,
+                        Restrictions = entry.Restrictions,
+                        Signature = entry.Signature
+                    });
+                }
+            }
+
+            return clone;
+        }
+    }
+}

--- a/src/CSM.TmpeSync.VehicleRestrictions/Services/VehicleRestrictionSynchronization.cs
+++ b/src/CSM.TmpeSync.VehicleRestrictions/Services/VehicleRestrictionSynchronization.cs
@@ -5,6 +5,30 @@ namespace CSM.TmpeSync.VehicleRestrictions.Services
 {
     internal static class VehicleRestrictionSynchronization
     {
+        internal static void HandleClientConnect(CSM.API.Networking.Player player)
+        {
+            if (!CsmBridge.IsServerInstance())
+                return;
+
+            int clientId = CsmBridge.TryGetClientId(player);
+            if (clientId < 0)
+                return;
+
+            var cached = VehicleRestrictionStateCache.GetAll();
+            if (cached == null || cached.Count == 0)
+                return;
+
+            Log.Info(
+                LogCategory.Synchronization,
+                LogRole.Host,
+                "[VehicleRestrictions] Resync for reconnecting client | target={0} items={1}",
+                clientId,
+                cached.Count);
+
+            foreach (var state in cached)
+                CsmBridge.SendToClient(clientId, state);
+        }
+
         internal static bool TryRead(ushort segmentId, out Messages.VehicleRestrictionsAppliedCommand command)
         {
             return VehicleRestrictionTmpeAdapter.TryGet(segmentId, out command);

--- a/src/CSM.TmpeSync/Mod/ModMetadata.cs
+++ b/src/CSM.TmpeSync/Mod/ModMetadata.cs
@@ -14,12 +14,16 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Latest release tag for CSM TM:PE Sync.
         /// </summary>
-        internal const string LatestCsmTmpeSyncReleaseTag = "v1.0.0.0";
+        internal const string LatestCsmTmpeSyncReleaseTag = "v1.1.0.0";
 
         /// <summary>
         /// Legacy release tags for CSM TM:PE Sync (excluding the latest).
         /// </summary>
-        internal static readonly string[] LegacyCsmTmpeSyncReleaseTags = new string[0];
+        internal static readonly string[] LegacyCsmTmpeSyncReleaseTags = new[]
+        {
+            "v1.0.1.0",
+            "v1.0.0.0",
+        };
 
         /// <summary>
         /// Latest release tag for Traffic Manager: President Edition.

--- a/src/CSM.TmpeSync/Mod/ModMetadata.cs
+++ b/src/CSM.TmpeSync/Mod/ModMetadata.cs
@@ -9,7 +9,7 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Current version of the CSM TM:PE Sync mod. Update this value when publishing new builds.
         /// </summary>
-        internal const string NewVersion = "v1.0.1.0";
+        internal const string NewVersion = "v1.1.0.0";
 
         /// <summary>
         /// Latest release tag for CSM TM:PE Sync.

--- a/src/CSM.TmpeSync/Services/UI/ChangelogPanel.cs
+++ b/src/CSM.TmpeSync/Services/UI/ChangelogPanel.cs
@@ -164,6 +164,16 @@ namespace CSM.TmpeSync.Services.UI
             {
                 new ChangelogEntry
                 {
+                    Version = "1.1.0.0",
+                    Date = "2025-12-06",
+                    Changes = new List<string>
+                    {
+                        "Improve resync logic: when a client rejoins, the host replays all TM:PE changes made since the host came online, including those performed while the client was offline.",
+                        "Includes the 1.0.1.0 updates: in-game changelog popup and client lane connection fix."
+                    }
+                },
+                new ChangelogEntry
+                {
                     Version = "1.0.1.0",
                     Date = "2025-12-04",
                     Changes = new List<string>


### PR DESCRIPTION
# Changelog 
- Resync on rejoin now replays all TM:PE changes since the host came online (including while the client was offline) and bundles the 1.0.1.0 updates (changelog popup + client lane connection fix).