### PR TITLE
Update for Cities: Skylines 1.21 & TM:PE 11.9.4.1 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog - CSM.TmpeSync
+
+## [v1.2.0.0] - 2026-03-24
+
+### Updated Compatibility
+- Updated `ModMetadata.cs` to support:
+    - Cities: Skylines 1.21 (latest)
+    - Cities: Skylines Multiplayer (CSM) v2603.307
+    - Traffic Manager: President Edition (TM:PE) 11.9.4.1
+
+### Improvements & Robustness
+- **Network Resilience**: Added defensive bounds checks in `NetworkUtil.cs` to prevent "Array index is out of range" exceptions when accessing game buffers (Nodes, Segments, Lanes).
+- **Reflection Logic**: Enhanced `CsmBridge.cs` with assembly-aware type resolution. This ensures that internal CSM types in `csm.dll` are correctly resolved even when the mod is loaded in complex environments.
+- **Harmony Patching**: Refined `LaneConnectorEventListener.cs` to use more granular method signature matching. Added extra logging to capture failures when patching TM:PE managers.
+
+### Bug Fixes
+- Fixed a potential issue where "Move Building" (via CSM's new rebuild handler) could be interfered with by outdated mod version states.
+- Aligned synchronization handlers with the latest TM:PE internal manager signatures to ensure stability during lane connection changes.

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Configuration: Set the path to your Cities: Skylines installation directory.
+# You can also set the CITIES_SKYLINES_DIR environment variable instead of editing this script.
+REAL_GAME_DIR="${CITIES_SKYLINES_DIR:-/var/mnt/schijven/1TB SSD/Games/Cities - Skylines/drive_c/Program Files (x86)/Cities.Skylines.v1.21.1.F5}"
+
+# Check if the game directory exists
+if [ ! -d "$REAL_GAME_DIR" ]; then
+    echo "Error: Game directory not found at '$REAL_GAME_DIR'"
+    echo "Please set the CITIES_SKYLINES_DIR environment variable or update the script."
+    exit 1
+fi
+
+# Use a symbolic link to handle spaces in paths (important for MSBuild on some Linux versions)
+GAME_DIR="/tmp/cs_game"
+rm -f "$GAME_DIR"
+ln -s "$REAL_GAME_DIR" "$GAME_DIR"
+
+MANAGED_DIR="$GAME_DIR/Cities_Data/Managed"
+
+echo "=== Building CSM.API submodule ==="
+# Restore and build the CSM.API dependency from the submodule
+dotnet build "submodule/CSM/src/api/CSM.API.csproj" -c Release \
+    /p:CitiesSkylinesDir="$GAME_DIR" \
+    /p:ManagedDir="$MANAGED_DIR"
+
+if [ $? -ne 0 ]; then
+    echo "CSM.API build failed!"
+    exit 1
+fi
+
+echo "=== Building CSM.TmpeSync mod ==="
+
+# Automatically search for mod dependencies (Harmony and TM:PE) in the game's Mods folder
+HARMONY_DLL=$(find "$REAL_GAME_DIR/Files/Mods/" -name "CitiesHarmony.Harmony.dll" 2>/dev/null | head -n 1)
+
+if [ -z "$HARMONY_DLL" ]; then
+    echo "Error: CitiesHarmony.Harmony.dll not found in $REAL_GAME_DIR/Files/Mods/"
+    exit 1
+fi
+
+echo "Found CitiesHarmony at: $HARMONY_DLL"
+
+# Create a temporary reference directory for MSBuild
+REF_DIR="/tmp/cs_refs"
+rm -rf "$REF_DIR"
+mkdir -p "$REF_DIR/Harmony"
+mkdir -p "$REF_DIR/TMPE/Cities_Data/Managed"
+
+# Link dependency DLLs into the reference directory
+ln -s "$HARMONY_DLL" "$REF_DIR/Harmony/CitiesHarmony.Harmony.dll"
+
+# Link all DLLs from the TM:PE folder (using the default folder name for stability)
+# If your TM:PE mod folder has a different name, the find command will attempt a search.
+TMPE_SEARCH_DIR=$(find "$REAL_GAME_DIR/Files/Mods/" -maxdepth 1 -type d -name "TMPE*" 2>/dev/null | head -n 1)
+
+if [ -z "$TMPE_SEARCH_DIR" ]; then
+    echo "Error: TM:PE mod directory not found!"
+    exit 1
+fi
+
+echo "Found TM:PE at: $TMPE_SEARCH_DIR"
+find "$TMPE_SEARCH_DIR/" -name "*.dll" -exec ln -s {} "$REF_DIR/TMPE/Cities_Data/Managed/" \;
+
+# Verify TrafficManager.dll exists
+if [ ! -f "$REF_DIR/TMPE/Cities_Data/Managed/TrafficManager.dll" ]; then
+    echo "Error: TrafficManager.dll not found in TM:PE folder!"
+    exit 1
+fi
+
+# Build the main mod project and its features
+dotnet build "src/CSM.TmpeSync/CSM.TmpeSync.csproj" -c Release \
+    /p:CitiesSkylinesDir="$GAME_DIR" \
+    /p:ManagedDir="$MANAGED_DIR" \
+    /p:HarmonyDllDir="$REF_DIR/Harmony" \
+    /p:TmpeDir="$REF_DIR/TMPE" \
+    /p:CsmApiDllPath="$(pwd)/submodule/CSM/src/api/bin/Release/CSM.API.dll"
+
+if [ $? -ne 0 ]; then
+    echo "CSM.TmpeSync build failed!"
+    exit 1
+fi
+
+echo "=== Build Complete ==="
+echo "Artifacts are located in: src/CSM.TmpeSync/bin/Release/net35/"
+echo "Copy all .dll files from the above folder to your game's Addons/Mods directory."

--- a/src/CSM.TmpeSync.LaneConnector/Services/LaneConnectorEventListener.cs
+++ b/src/CSM.TmpeSync.LaneConnector/Services/LaneConnectorEventListener.cs
@@ -128,18 +128,32 @@ namespace CSM.TmpeSync.LaneConnector.Services
                 if (type == null || postfix == null)
                     return 0;
 
-                var candidates = type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                    .Where(m => m.Name == methodName)
-                    .ToArray();
-
-                int count = 0;
-                foreach (var method in candidates)
+                try
                 {
-                    harmony.Patch(method, postfix: new HarmonyMethod(postfix));
-                    count++;
-                }
+                    var candidates = type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                        .Where(m => m.Name == methodName)
+                        .ToArray();
 
-                return count;
+                    if (candidates.Length == 0)
+                    {
+                        Log.Warn(LogCategory.Network, LogRole.Host, "[LaneConnector] No candidates found for method {0}.{1}", type.FullName, methodName);
+                        return 0;
+                    }
+
+                    int count = 0;
+                    foreach (var method in candidates)
+                    {
+                        harmony.Patch(method, postfix: new HarmonyMethod(postfix));
+                        count++;
+                    }
+
+                    return count;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(LogCategory.Network, LogRole.Host, "[LaneConnector] Failed to patch method {0}.{1}: {2}", type.FullName, methodName, ex);
+                    return 0;
+                }
             }
 
             private static void PostLaneConnectionChanged(uint sourceLaneId, uint targetLaneId, bool sourceStartNode)

--- a/src/CSM.TmpeSync/Mod/ModMetadata.cs
+++ b/src/CSM.TmpeSync/Mod/ModMetadata.cs
@@ -9,19 +9,18 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Current version of the CSM TM:PE Sync mod. Update this value when publishing new builds.
         /// </summary>
-        internal const string NewVersion = "v2.1.0.0";
+        internal const string NewVersion = "v1.2.0.0";
 
         /// <summary>
         /// Latest release tag for CSM TM:PE Sync.
         /// </summary>
-        internal const string LatestCsmTmpeSyncReleaseTag = "v2.1.0.0";
+        internal const string LatestCsmTmpeSyncReleaseTag = "v1.2.0.0";
 
         /// <summary>
         /// Legacy release tags for CSM TM:PE Sync (excluding the latest).
         /// </summary>
         internal static readonly string[] LegacyCsmTmpeSyncReleaseTags = new[]
         {
-            "v1.2.0.0",
             "v1.1.0.0",
             "v1.0.1.0",
             "v1.0.0.0",

--- a/src/CSM.TmpeSync/Mod/ModMetadata.cs
+++ b/src/CSM.TmpeSync/Mod/ModMetadata.cs
@@ -9,18 +9,19 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Current version of the CSM TM:PE Sync mod. Update this value when publishing new builds.
         /// </summary>
-        internal const string NewVersion = "v1.2.0.0";
+        internal const string NewVersion = "v2.1.0.0";
 
         /// <summary>
         /// Latest release tag for CSM TM:PE Sync.
         /// </summary>
-        internal const string LatestCsmTmpeSyncReleaseTag = "v1.2.0.0";
+        internal const string LatestCsmTmpeSyncReleaseTag = "v2.1.0.0";
 
         /// <summary>
         /// Legacy release tags for CSM TM:PE Sync (excluding the latest).
         /// </summary>
         internal static readonly string[] LegacyCsmTmpeSyncReleaseTags = new[]
         {
+            "v1.2.0.0",
             "v1.1.0.0",
             "v1.0.1.0",
             "v1.0.0.0",

--- a/src/CSM.TmpeSync/Mod/ModMetadata.cs
+++ b/src/CSM.TmpeSync/Mod/ModMetadata.cs
@@ -9,18 +9,19 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Current version of the CSM TM:PE Sync mod. Update this value when publishing new builds.
         /// </summary>
-        internal const string NewVersion = "v1.1.0.0";
+        internal const string NewVersion = "v1.2.0.0";
 
         /// <summary>
         /// Latest release tag for CSM TM:PE Sync.
         /// </summary>
-        internal const string LatestCsmTmpeSyncReleaseTag = "v1.1.0.0";
+        internal const string LatestCsmTmpeSyncReleaseTag = "v1.2.0.0";
 
         /// <summary>
         /// Legacy release tags for CSM TM:PE Sync (excluding the latest).
         /// </summary>
         internal static readonly string[] LegacyCsmTmpeSyncReleaseTags = new[]
         {
+            "v1.1.0.0",
             "v1.0.1.0",
             "v1.0.0.0",
         };
@@ -28,13 +29,14 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Latest release tag for Traffic Manager: President Edition.
         /// </summary>
-        internal const string LatestTmpeReleaseTag = "11.9.3.0";
+        internal const string LatestTmpeReleaseTag = "11.9.4.1";
 
         /// <summary>
         /// Legacy release tags for Traffic Manager: President Edition (excluding the latest).
         /// </summary>
         internal static readonly string[] LegacyTmpeReleaseTags = new[]
         {
+            "11.9.3.0",
             "11.9.2.0",
             "11.9.1.0",
             "11.9.0.0",
@@ -106,13 +108,14 @@ namespace CSM.TmpeSync.Mod
         /// <summary>
         /// Latest release tag for Cities: Skylines Multiplayer.
         /// </summary>
-        internal const string LatestCsmReleaseTag = "v2511.301";
+        internal const string LatestCsmReleaseTag = "v2603.307";
 
         /// <summary>
         /// Legacy release tags for Cities: Skylines Multiplayer (excluding the latest).
         /// </summary>
         internal static readonly string[] LegacyCsmReleaseTags = new[]
         {
+            "v2511.301",
             "v2511.296",
             "v2309.286",
             "v2305.270",

--- a/src/CSM.TmpeSync/Services/CsmBridge.cs
+++ b/src/CSM.TmpeSync/Services/CsmBridge.cs
@@ -41,12 +41,26 @@ namespace CSM.TmpeSync.Services
             TrySendToClientInternal(clientId, command);
         }
 
+        private static Type GetTypeFromAssemblies(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type != null) return type;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                type = assembly.GetType(typeName);
+                if (type != null) return type;
+            }
+
+            return null;
+        }
+
         private static bool TrySendToClientInternal(int clientId, CommandBase command)
         {
             try
             {
-                var cmdInternalType = Type.GetType("CSM.Commands.CommandInternal");
-                var mmType = Type.GetType("CSM.Networking.MultiplayerManager");
+                var cmdInternalType = GetTypeFromAssemblies("CSM.Commands.CommandInternal");
+                var mmType = GetTypeFromAssemblies("CSM.Networking.MultiplayerManager");
                 if (cmdInternalType == null || mmType == null)
                     return false;
 
@@ -122,7 +136,7 @@ namespace CSM.TmpeSync.Services
                 var username = player?.GetType().GetProperty("Username")?.GetValue(player, null) as string;
                 if (!string.IsNullOrEmpty(username))
                 {
-                    var mmType = Type.GetType("CSM.Networking.MultiplayerManager");
+                    var mmType = GetTypeFromAssemblies("CSM.Networking.MultiplayerManager");
                     var mmInstance = mmType?.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)?.GetValue(null, null);
                     var currentServer = mmType?.GetProperty("CurrentServer", BindingFlags.Public | BindingFlags.Instance)?.GetValue(mmInstance, null);
                     var players = currentServer?.GetType().GetProperty("ConnectedPlayers", BindingFlags.Public | BindingFlags.Instance)?.GetValue(currentServer, null) as IDictionary;

--- a/src/CSM.TmpeSync/Services/NetworkUtil.cs
+++ b/src/CSM.TmpeSync/Services/NetworkUtil.cs
@@ -198,7 +198,11 @@ namespace CSM.TmpeSync.Services
             if (segmentId == 0)
                 return false;
 
-            return (NetManager.instance.m_segments.m_buffer[segmentId].m_flags & NetSegment.Flags.Created) != 0;
+            var buffer = NetManager.instance.m_segments.m_buffer;
+            if (segmentId >= buffer.Length)
+                return false;
+
+            return (buffer[segmentId].m_flags & NetSegment.Flags.Created) != 0;
         }
 
         internal static bool NodeExists(ushort nodeId)
@@ -206,7 +210,11 @@ namespace CSM.TmpeSync.Services
             if (nodeId == 0)
                 return false;
 
-            return (NetManager.instance.m_nodes.m_buffer[nodeId].m_flags & NetNode.Flags.Created) != 0;
+            var buffer = NetManager.instance.m_nodes.m_buffer;
+            if (nodeId >= buffer.Length)
+                return false;
+
+            return (buffer[nodeId].m_flags & NetNode.Flags.Created) != 0;
         }
 
         internal static void ForEachLane(Action<uint> action)

--- a/src/CSM.TmpeSync/Services/UI/ChangelogPanel.cs
+++ b/src/CSM.TmpeSync/Services/UI/ChangelogPanel.cs
@@ -164,6 +164,18 @@ namespace CSM.TmpeSync.Services.UI
             {
                 new ChangelogEntry
                 {
+                    Version = "1.2.0.0",
+                    Date = "2026-03-24",
+                    Changes = new List<string>
+                    {
+                        "Compatibility: Update for Cities: Skylines 1.21, CSM 2603.307, and TM:PE 11.9.4.1.",
+                        "Stability: Added defensive bounds checks for node and segment IDs to prevent 'Array index out of range' crashes.",
+                        "Robustness: Improved internal CSM type resolution using cross-assembly reflection.",
+                        "Linux Support: Fixed .NET 3.5 build errors and added a new automated build script."
+                    }
+                },
+                new ChangelogEntry
+                {
                     Version = "1.1.0.0",
                     Date = "2025-12-06",
                     Changes = new List<string>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    <RepoRoot Condition="'$(RepoRoot)'==''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..'))</RepoRoot>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,18 +22,18 @@
              Condition="'$(MSBuildProjectName)' != 'CSM.TmpeSync'" />
   </ItemGroup>
 
-  <!-- Local TM:PE references to satisfy compile-time API usage when TM:PE isn't installed under Steam paths. -->
-  <ItemGroup>
-    <Reference Include="TrafficManager" Condition="Exists('$(RepoRoot)\lib\TMPE\TrafficManager.dll')">
-      <HintPath>$(RepoRoot)\lib\TMPE\TrafficManager.dll</HintPath>
+  <!-- Global TM:PE references when TmpeDir is provided via command line -->
+  <ItemGroup Condition="'$(TmpeDir)'!=''">
+    <Reference Include="TrafficManager.API" Condition="Exists('$(TmpeDir)\Cities_Data\Managed\TrafficManager.API.dll')">
+      <HintPath>$(TmpeDir)\Cities_Data\Managed\TrafficManager.API.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="CSUtil.Commons" Condition="Exists('$(RepoRoot)\lib\TMPE\CSUtil.Commons.dll')">
-      <HintPath>$(RepoRoot)\lib\TMPE\CSUtil.Commons.dll</HintPath>
+    <Reference Include="TMPE.API" Condition="Exists('$(TmpeDir)\Cities_Data\Managed\TMPE.API.dll')">
+      <HintPath>$(TmpeDir)\Cities_Data\Managed\TMPE.API.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="TMPE.API" Condition="Exists('$(RepoRoot)\lib\TMPE\TMPE.API.dll')">
-      <HintPath>$(RepoRoot)\lib\TMPE\TMPE.API.dll</HintPath>
+    <Reference Include="CSUtil.Commons" Condition="Exists('$(TmpeDir)\Cities_Data\Managed\CSUtil.Commons.dll')">
+      <HintPath>$(TmpeDir)\Cities_Data\Managed\CSUtil.Commons.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
This PR updates CSM.TmpeSync for compatibility with Cities: Skylines 1.21, CSM version 2603.307, and TM:PE 11.9.4.1. It includes critical stability fixes to prevent "Array index out of range" crashes, improved reflection-based type lookup for CSM internals, and full build support for Linux environments.

Works with: 
- https://github.com/CitiesSkylinesMultiplayer/CSM/releases/tag/v2603.307
- https://github.com/CitiesSkylinesMods/TMPE/releases/tag/11.9.4.1